### PR TITLE
Vote 도메인 Service 관련 테스트 클래스, SpringContext 분리 처리

### DIFF
--- a/src/test/java/com/j2kb/codev21/domains/vote/service/VoteServiceTest.java
+++ b/src/test/java/com/j2kb/codev21/domains/vote/service/VoteServiceTest.java
@@ -12,7 +12,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -29,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @SpringBootTest
 @ActiveProfiles({ "vote_test_init", "dev", "secret" })
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @ExtendWith({ SpringExtension.class, MockitoExtension.class })
 class VoteServiceTest {
 

--- a/src/test/java/com/j2kb/codev21/domains/vote/service/exception/VoteServiceExceptionTest.java
+++ b/src/test/java/com/j2kb/codev21/domains/vote/service/exception/VoteServiceExceptionTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -26,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @SpringBootTest
 @ActiveProfiles({ "vote_test_init", "dev", "secret" })
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @ExtendWith({ SpringExtension.class, MockitoExtension.class })
 public class VoteServiceExceptionTest {
 	


### PR DESCRIPTION
[fix] Vote 도메인 Service 관련 테스트 클래스, SpringContext 분리 처리
* 각 테스트가 주입하는 데이터들이 중복되어 의도한대로 테스트가 실행되지 않아, SpringContext를 공유하지 않도록 분리 처리함



빌드를 해보지 않고 올려 Spring Test 시 테스트가 서로 부딪히는 것을 확인하지 못했습니다! 급하게 수정해서 머지합니다.